### PR TITLE
Add bUnit test coverage for ChartIsland LiveCharts integration

### DIFF
--- a/EquipmentHubDemo.sln
+++ b/EquipmentHubDemo.sln
@@ -9,6 +9,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EquipmentHubDemo.Client", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Agent", "EquipmentHubDemo\Agent\Agent.csproj", "{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EquipmentHubDemo/EquipmentHubDemo", "EquipmentHubDemo\EquipmentHubDemo", "{05C5E76E-70FD-46B8-9973-60B036ED9FEE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EquipmentHubDemo", "EquipmentHubDemo", "{B5F3CD86-FB89-457D-95F1-2F1295CBE767}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EquipmentHubDemo.Components.Tests", "EquipmentHubDemo\EquipmentHubDemo.Components.Tests\EquipmentHubDemo.Components.Tests.csproj", "{8EC41560-B252-4FCC-BB74-4F22FD5A7665}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,11 +33,19 @@ Global
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9763D6CC-1C3B-4016-9725-5E66676D34A2}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{98413BD3-2707-4985-881C-7B724B20C913} = {05C5E76E-70FD-46B8-9973-60B036ED9FEE}
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
 	EndGlobalSection
 EndGlobal

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/ChartIslandTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/ChartIslandTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.ObjectModel;
+using System.Reflection;
+using Bunit;
+using EquipmentHubDemo.Components.Pages;
+using EquipmentHubDemo.Domain;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using Xunit;
+
+namespace EquipmentHubDemo.Components.Tests;
+
+public sealed class ChartIslandTests : TestContext
+{
+    [Fact]
+    public void ChartIsland_RendersCartesianChartAndTracksIncomingPoints()
+    {
+        // Arrange
+        var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var points = new[]
+        {
+            new PointDto { X = baseTime, Y = 3.5 },
+            new PointDto { X = baseTime.AddSeconds(1), Y = 7.25 }
+        };
+
+        // Act
+        var cut = RenderComponent<ChartIsland>(parameters => parameters
+            .Add(p => p.Title, "Telemetry")
+            .Add(p => p.Points, points));
+
+        // Assert
+        var status = cut.Find("p").TextContent.Trim();
+        Assert.Equal($"island points: {points.Length}", status);
+
+        var chartElement = cut.Find("cartesianchart");
+        Assert.NotNull(chartElement);
+
+        var instance = cut.Instance;
+
+        var valuesField = typeof(ChartIsland).GetField("_values", BindingFlags.Instance | BindingFlags.NonPublic);
+        var values = Assert.IsAssignableFrom<ObservableCollection<ObservablePoint>>(valuesField?.GetValue(instance));
+        Assert.Equal(points.Length, values.Count);
+        Assert.Equal(points[0].X.ToOADate(), values[0].X);
+        Assert.Equal(points[0].Y, values[0].Y);
+        Assert.Equal(points[1].X.ToOADate(), values[1].X);
+        Assert.Equal(points[1].Y, values[1].Y);
+
+        var axesField = typeof(ChartIsland).GetField("xAxes", BindingFlags.Instance | BindingFlags.NonPublic);
+        var axes = Assert.IsAssignableFrom<Axis[]>(axesField?.GetValue(instance));
+        Assert.Equal("Telemetry", axes[0].Name);
+    }
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/EquipmentHubDemo.Components.Tests.csproj
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/EquipmentHubDemo.Components.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="1.30.6" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EquipmentHubDemo\EquipmentHubDemo.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a dedicated EquipmentHubDemo.Components.Tests project that targets net9.0 and references bUnit/xUnit tooling
- cover the ChartIsland component with a bUnit test that renders the CartesianChart and inspects the LiveCharts data bindings
- register the new test project in the solution for future validation runs

## Testing
- dotnet test EquipmentHubDemo.sln *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ef578568832ca67e1c03dd7b604d