### PR TITLE
Ensure LiveCharts assets load in home chart

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo/Components/Layout/MainLayout.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/Layout/MainLayout.razor
@@ -1,5 +1,9 @@
 ﻿@inherits LayoutComponentBase
 
+<HeadContent>
+    <script src="_content/LiveChartsCore.SkiaSharpView.Blazor/livecharts-blazor.js"></script>
+</HeadContent>
+
 <div class="container py-3">
     <header class="mb-3 border-bottom pb-2">
         <h1 class="h4 m-0">EquipmentHubDemo</h1>

--- a/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/ChartIsland.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/ChartIsland.razor
@@ -1,6 +1,7 @@
 ﻿@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @using Microsoft.AspNetCore.Components.Web
 @using System.Collections.ObjectModel
+@using System.Threading
 @using LiveChartsCore
 @using LiveChartsCore.Defaults
 @using LiveChartsCore.SkiaSharpView
@@ -16,7 +17,7 @@
     [Parameter] public IReadOnlyList<PointDto> Points { get; set; } = Array.Empty<PointDto>();
     [Parameter] public string? Title { get; set; }
 
-    private static bool _configured;
+    private static int _configuredFlag;
 
     private readonly ObservableCollection<ObservablePoint> _values = new();
     private readonly Axis[] xAxes = { new Axis { Name = "Time", Labeler = v => DateTime.FromOADate(v).ToString("HH:mm:ss") } };
@@ -28,10 +29,9 @@
 
     protected override void OnInitialized()
     {
-        if (!_configured)
+        if (Interlocked.Exchange(ref _configuredFlag, 1) == 0)
         {
             LiveCharts.Configure(cfg => cfg.AddSkiaSharp()); // must happen in WASM context
-            _configured = true;
         }
 
         Series = new ISeries[]

--- a/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
@@ -4,6 +4,7 @@
 @namespace EquipmentHubDemo.Components.Pages
 
 @using System.Collections.ObjectModel
+@using System.Threading
 @using LiveChartsCore
 @using LiveChartsCore.Defaults
 @using LiveChartsCore.SkiaSharpView
@@ -44,6 +45,8 @@
     private string? selectedKey;
     private bool running = true;
 
+    private static int _chartsConfiguredFlag;
+
     private readonly ObservableCollection<ObservablePoint> _values = new();
     private ISeries[] Series = Array.Empty<ISeries>();
     private readonly Axis[] xAxes = { new Axis { Name = "Time", Labeler = v => DateTime.FromOADate(v).ToString("HH:mm:ss") } };
@@ -58,7 +61,10 @@
     {
         try
         {
-            LiveCharts.Configure(cfg => cfg.AddSkiaSharp());
+            if (Interlocked.Exchange(ref _chartsConfiguredFlag, 1) == 0)
+            {
+                LiveCharts.Configure(cfg => cfg.AddSkiaSharp());
+            }
 
             Series = new ISeries[]
             {


### PR DESCRIPTION
## Summary
- load the LiveCharts Blazor script from the main layout so charts can initialize when the app starts
- guard LiveCharts configuration in the home and chart island components to avoid duplicate setup across renders

## Testing
- not run (requires .NET 9 SDK which is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d5f539c514832cbc97aea794d86181