### PR TITLE
Refactor agent to use configurable hosted publisher

### DIFF
--- a/EquipmentHubDemo.sln
+++ b/EquipmentHubDemo.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36221.1 d17.14
+VisualStudioVersion = 17.14.36221.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EquipmentHubDemo", "EquipmentHubDemo\EquipmentHubDemo\EquipmentHubDemo.csproj", "{98413BD3-2707-4985-881C-7B724B20C913}"
 EndProject
@@ -12,37 +13,88 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EquipmentHubDemo", "Equipme
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EquipmentHubDemo.Components.Tests", "EquipmentHubDemo\EquipmentHubDemo.Components.Tests\EquipmentHubDemo.Components.Tests.csproj", "{8EC41560-B252-4FCC-BB74-4F22FD5A7665}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Agent.Tests", "EquipmentHubDemo\Agent.Tests\Agent.Tests.csproj", "{9E082863-0FA0-473F-9702-9A21A03E4086}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|x64.Build.0 = Debug|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Debug|x86.Build.0 = Debug|Any CPU
 		{98413BD3-2707-4985-881C-7B724B20C913}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98413BD3-2707-4985-881C-7B724B20C913}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Release|x64.ActiveCfg = Release|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Release|x64.Build.0 = Release|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Release|x86.ActiveCfg = Release|Any CPU
+		{98413BD3-2707-4985-881C-7B724B20C913}.Release|x86.Build.0 = Release|Any CPU
 		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Debug|x86.Build.0 = Debug|Any CPU
 		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|x64.Build.0 = Release|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{63A5F2B7-0086-479D-804A-0981C957C9D6}.Release|x86.Build.0 = Release|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|x64.Build.0 = Debug|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Debug|x86.Build.0 = Debug|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|x64.Build.0 = Release|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7AF0E12-968F-8A00-A4DA-D466E8EB2793}.Release|x86.Build.0 = Release|Any CPU
 		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|x64.Build.0 = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Debug|x86.Build.0 = Debug|Any CPU
 		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|x64.ActiveCfg = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|x64.Build.0 = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|x86.ActiveCfg = Release|Any CPU
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665}.Release|x86.Build.0 = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|x64.Build.0 = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E082863-0FA0-473F-9702-9A21A03E4086}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{98413BD3-2707-4985-881C-7B724B20C913} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
+		{8EC41560-B252-4FCC-BB74-4F22FD5A7665} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
+		{9E082863-0FA0-473F-9702-9A21A03E4086} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
+	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9763D6CC-1C3B-4016-9725-5E66676D34A2}
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-                {98413BD3-2707-4985-881C-7B724B20C913} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
-		{8EC41560-B252-4FCC-BB74-4F22FD5A7665} = {B5F3CD86-FB89-457D-95F1-2F1295CBE767}
 	EndGlobalSection
 EndGlobal

--- a/EquipmentHubDemo/Agent.Tests/Agent.Tests.csproj
+++ b/EquipmentHubDemo/Agent.Tests/Agent.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Agent\Agent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EquipmentHubDemo/Agent.Tests/ProgramTests.cs
+++ b/EquipmentHubDemo/Agent.Tests/ProgramTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Agent.Tests;
+
+public static class ProgramTests
+{
+    [Fact]
+    public static void MeasureKey_ToString_ReturnsInstrumentAndMetric()
+    {
+        var key = new MeasureKey("UXG-99", "Noise");
+
+        var result = key.ToString();
+
+        Assert.Equal("UXG-99:Noise", result);
+    }
+
+    [Fact]
+    public static void Measurement_WithExpression_CreatesUpdatedCopy()
+    {
+        var timestamp = new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Utc);
+        var key = new MeasureKey("UXG-42", "Power");
+        var measurement = new Measurement(key, 10.5, timestamp);
+
+        var updated = measurement with { Value = 12.3 };
+
+        Assert.Equal(key, updated.Key);
+        Assert.Equal(timestamp, updated.TimestampUtc);
+        Assert.Equal(12.3, updated.Value);
+        Assert.NotSame(measurement, updated);
+    }
+
+    [Fact]
+    public static void Measurement_SerializesWithCamelCasePropertyNames()
+    {
+        var timestamp = new DateTime(2024, 05, 06, 07, 08, 09, DateTimeKind.Utc);
+        var measurement = new Measurement(
+            new MeasureKey("UXG-11", "SNR"),
+            42.1,
+            timestamp);
+
+        using var jsonDoc = JsonDocument.Parse(JsonSerializer.Serialize(measurement, MeasurementJson.Options));
+        var root = jsonDoc.RootElement;
+
+        Assert.True(root.TryGetProperty("key", out var keyElement));
+        Assert.Equal("UXG-11", keyElement.GetProperty("instrumentId").GetString());
+        Assert.Equal("SNR", keyElement.GetProperty("metric").GetString());
+        Assert.Equal(42.1, root.GetProperty("value").GetDouble());
+        Assert.Equal(timestamp, root.GetProperty("timestampUtc").GetDateTime().ToUniversalTime());
+    }
+
+    [Fact]
+    public static void MeasurementGenerator_RespectsConfiguredInstrumentsAndMetrics()
+    {
+        var options = Options.Create(new AgentOptions
+        {
+            Instruments = new List<InstrumentOptions>
+            {
+                new()
+                {
+                    InstrumentId = "A-01",
+                    Metrics = new List<string> { "Power" }
+                },
+                new()
+                {
+                    InstrumentId = "B-02",
+                    Metrics = new List<string> { "SNR", "Custom" }
+                }
+            }
+        });
+        options.Value.Normalize();
+
+        var generator = new MeasurementGenerator(options, new Random(0), NullLogger<MeasurementGenerator>.Instance);
+        var timestamp = new DateTime(2024, 07, 08, 09, 10, 11, DateTimeKind.Utc);
+
+        var results = generator.CreateMeasurements(timestamp).ToList();
+
+        Assert.Equal(3, results.Count);
+        Assert.Contains(results, m => m.Key.InstrumentId == "A-01" && m.Key.Metric == "Power");
+        Assert.Contains(results, m => m.Key.InstrumentId == "B-02" && m.Key.Metric == "SNR");
+        Assert.Contains(results, m => m.Key.InstrumentId == "B-02" && m.Key.Metric == "Custom");
+    }
+}

--- a/EquipmentHubDemo/Agent/Agent.csproj
+++ b/EquipmentHubDemo/Agent/Agent.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="NetMQ" Version="4.0.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/EquipmentHubDemo/Agent/AgentOptions.cs
+++ b/EquipmentHubDemo/Agent/AgentOptions.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Agent;
+
+public sealed class AgentOptions
+{
+    private static readonly TimeSpan DefaultPublishInterval = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan DefaultRetryBackoff = TimeSpan.FromMilliseconds(100);
+
+    public string PublishEndpoint { get; set; } = "tcp://127.0.0.1:5556";
+
+    public string Topic { get; set; } = "measure";
+
+    public int PublishIntervalMilliseconds { get; set; } = (int)DefaultPublishInterval.TotalMilliseconds;
+
+    public int SendRetryCount { get; set; } = 3;
+
+    public int SendRetryBackoffMilliseconds { get; set; } = (int)DefaultRetryBackoff.TotalMilliseconds;
+
+    public List<InstrumentOptions> Instruments { get; set; } = CreateDefaultInstruments();
+
+    public TimeSpan PublishInterval => TimeSpan.FromMilliseconds(PublishIntervalMilliseconds);
+
+    public TimeSpan RetryBackoff => TimeSpan.FromMilliseconds(SendRetryBackoffMilliseconds);
+
+    public void Normalize()
+    {
+        PublishEndpoint = string.IsNullOrWhiteSpace(PublishEndpoint)
+            ? "tcp://127.0.0.1:5556"
+            : PublishEndpoint.Trim();
+
+        Topic = string.IsNullOrWhiteSpace(Topic)
+            ? "measure"
+            : Topic.Trim();
+
+        if (PublishIntervalMilliseconds <= 0)
+        {
+            PublishIntervalMilliseconds = (int)DefaultPublishInterval.TotalMilliseconds;
+        }
+
+        if (SendRetryCount <= 0)
+        {
+            SendRetryCount = 3;
+        }
+
+        if (SendRetryBackoffMilliseconds < 0)
+        {
+            SendRetryBackoffMilliseconds = (int)DefaultRetryBackoff.TotalMilliseconds;
+        }
+
+        Instruments = (Instruments ?? new List<InstrumentOptions>())
+            .Select(i => i?.Clone())
+            .Where(i => i is not null)
+            .Cast<InstrumentOptions>()
+            .ToList();
+
+        foreach (var instrument in Instruments.ToList())
+        {
+            instrument.Normalize();
+            if (string.IsNullOrWhiteSpace(instrument.InstrumentId) || instrument.Metrics.Count == 0)
+            {
+                Instruments.Remove(instrument);
+            }
+        }
+
+        if (Instruments.Count == 0)
+        {
+            Instruments = CreateDefaultInstruments();
+        }
+    }
+
+    private static List<InstrumentOptions> CreateDefaultInstruments() =>
+        new()
+        {
+            new InstrumentOptions
+            {
+                InstrumentId = "UXG-01",
+                Metrics = new List<string> { "Power", "SNR" }
+            },
+            new InstrumentOptions
+            {
+                InstrumentId = "UXG-02",
+                Metrics = new List<string> { "Power", "SNR" }
+            }
+        };
+}

--- a/EquipmentHubDemo/Agent/AgentPublisher.cs
+++ b/EquipmentHubDemo/Agent/AgentPublisher.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NetMQ;
+using NetMQ.Sockets;
+
+namespace Agent;
+
+internal sealed class AgentPublisher : BackgroundService
+{
+    private readonly AgentOptions _options;
+    private readonly IMeasurementGenerator _generator;
+    private readonly ILogger<AgentPublisher> _logger;
+
+    public AgentPublisher(IOptions<AgentOptions> options, IMeasurementGenerator generator, ILogger<AgentPublisher> logger)
+    {
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _generator = generator ?? throw new ArgumentNullException(nameof(generator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        AsyncIO.ForceDotNet.Force();
+        using var publisher = new PublisherSocket();
+        publisher.Options.Linger = TimeSpan.Zero;
+        publisher.Connect(_options.PublishEndpoint);
+
+        _logger.LogInformation(
+            "Publishing {InstrumentCount} instrument(s) to {Endpoint} on topic {Topic}.",
+            _options.Instruments.Count,
+            _options.PublishEndpoint,
+            _options.Topic);
+
+        using var timer = new PeriodicTimer(_options.PublishInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                var timestamp = DateTime.UtcNow;
+                foreach (var measurement in _generator.CreateMeasurements(timestamp))
+                {
+                    if (stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    await PublishWithRetryAsync(publisher, measurement, stoppingToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Agent publisher cancelled.");
+        }
+        finally
+        {
+            NetMQConfig.Cleanup();
+            _logger.LogInformation("Agent publisher stopped.");
+        }
+    }
+
+    private async Task PublishWithRetryAsync(PublisherSocket publisher, Measurement measurement, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.Serialize(measurement, MeasurementJson.Options);
+        var attempt = 1;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var message = new NetMQMessage(2);
+            message.Append(_options.Topic);
+            message.Append(payload);
+
+            try
+            {
+                publisher.SendMultipartMessage(message);
+
+                _logger.LogDebug(
+                    "Published measurement {Key} at {TimestampUtc:o} with value {Value:F3}.",
+                    measurement.Key,
+                    measurement.TimestampUtc,
+                    measurement.Value);
+                return;
+            }
+            catch (NetMQException ex) when (attempt < _options.SendRetryCount)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Attempt {Attempt} to publish measurement {Key} failed. Retrying in {Delay} ms.",
+                    attempt,
+                    measurement.Key,
+                    _options.SendRetryBackoffMilliseconds);
+
+                attempt++;
+                await Task.Delay(_options.RetryBackoff, cancellationToken).ConfigureAwait(false);
+            }
+            catch (NetMQException ex)
+            {
+                _logger.LogError(ex, "Failed to publish measurement {Key} after {Attempt} attempt(s).", measurement.Key, attempt);
+                return;
+            }
+        }
+    }
+}

--- a/EquipmentHubDemo/Agent/AssemblyInfo.cs
+++ b/EquipmentHubDemo/Agent/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Agent.Tests")]

--- a/EquipmentHubDemo/Agent/IMeasurementGenerator.cs
+++ b/EquipmentHubDemo/Agent/IMeasurementGenerator.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace Agent;
+
+internal interface IMeasurementGenerator
+{
+    IEnumerable<Measurement> CreateMeasurements(DateTime timestampUtc);
+}

--- a/EquipmentHubDemo/Agent/InstrumentOptions.cs
+++ b/EquipmentHubDemo/Agent/InstrumentOptions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Agent;
+
+public sealed class InstrumentOptions
+{
+    public string InstrumentId { get; set; } = string.Empty;
+
+    public List<string> Metrics { get; set; } = new();
+
+    internal InstrumentOptions Clone() => new()
+    {
+        InstrumentId = InstrumentId,
+        Metrics = (Metrics ?? new List<string>()).ToList()
+    };
+
+    internal void Normalize()
+    {
+        InstrumentId = InstrumentId?.Trim() ?? string.Empty;
+        var metrics = Metrics ?? new List<string>();
+        Metrics = metrics
+            .Where(m => !string.IsNullOrWhiteSpace(m))
+            .Select(m => m.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/EquipmentHubDemo/Agent/MeasurementGenerator.cs
+++ b/EquipmentHubDemo/Agent/MeasurementGenerator.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Agent;
+
+internal sealed class MeasurementGenerator : IMeasurementGenerator
+{
+    private readonly AgentOptions _options;
+    private readonly Random _random;
+    private readonly ILogger<MeasurementGenerator> _logger;
+
+    public MeasurementGenerator(IOptions<AgentOptions> options, Random random, ILogger<MeasurementGenerator> logger)
+    {
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _random = random ?? throw new ArgumentNullException(nameof(random));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public IEnumerable<Measurement> CreateMeasurements(DateTime timestampUtc)
+    {
+        var angle = timestampUtc.Ticks / 2e7d;
+        foreach (var instrument in _options.Instruments)
+        {
+            foreach (var metric in instrument.Metrics)
+            {
+                yield return CreateMeasurement(instrument.InstrumentId, metric, timestampUtc, angle);
+            }
+        }
+    }
+
+    private Measurement CreateMeasurement(string instrumentId, string metric, DateTime timestampUtc, double angle)
+    {
+        var trimmedMetric = metric?.Trim() ?? string.Empty;
+        var key = new MeasureKey(instrumentId, trimmedMetric);
+        var value = trimmedMetric.Length == 0
+            ? GenerateFallbackValue(trimmedMetric)
+            : GenerateValue(trimmedMetric, angle);
+
+        return new Measurement(key, value, timestampUtc);
+    }
+
+    private double GenerateValue(string metric, double angle)
+    {
+        if (string.Equals(metric, "Power", StringComparison.OrdinalIgnoreCase))
+        {
+            return 10 + 2 * Math.Sin(angle) + _random.NextDouble();
+        }
+
+        if (string.Equals(metric, "SNR", StringComparison.OrdinalIgnoreCase))
+        {
+            return 30 + 5 * Math.Cos(angle) + _random.NextDouble();
+        }
+
+        return GenerateFallbackValue(metric);
+    }
+
+    private double GenerateFallbackValue(string metric)
+    {
+        var value = _random.NextDouble();
+        _logger.LogDebug("No generator registered for metric {Metric}; using random value {Value:F3}.", metric, value);
+        return value;
+    }
+}

--- a/EquipmentHubDemo/Agent/MeasurementTypes.cs
+++ b/EquipmentHubDemo/Agent/MeasurementTypes.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace Agent;
+
+public readonly record struct MeasureKey(string InstrumentId, string Metric)
+{
+    public override string ToString() => $"{InstrumentId}:{Metric}";
+}
+
+public sealed record Measurement(MeasureKey Key, double Value, DateTime TimestampUtc);
+
+internal static class MeasurementJson
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/EquipmentHubDemo/Agent/Program.cs
+++ b/EquipmentHubDemo/Agent/Program.cs
@@ -1,88 +1,27 @@
-﻿// Agent/Program.cs
-using System;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using NetMQ;
-using NetMQ.Sockets;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Agent;
 
 internal static class Program
 {
-    private static readonly JsonSerializerOptions JsonOpts =
-        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-
-    private static readonly string[] Instruments = { "UXG-01", "UXG-02" };
-    private static readonly string[] Metrics = { "Power", "SNR" };
-
-    private const string PubConnect = "tcp://127.0.0.1:5556"; // connects to XSUB side
-    private const string TopicMeasure = "measure";
-
     public static async Task Main(string[] args)
     {
-        using var cts = new CancellationTokenSource();
-        Console.CancelKeyPress += (_, e) =>
-        {
-            e.Cancel = true;
-            cts.Cancel();
-        };
+        var builder = Host.CreateApplicationBuilder(args);
 
-        Console.WriteLine("Agent: publishing to 'measure' (Ctrl+C to stop)…");
+        builder.Services
+            .AddOptions<AgentOptions>()
+            .Bind(builder.Configuration.GetSection("Agent"))
+            .PostConfigure(options => options.Normalize());
 
-        // Required for NetMQ in .NET Core apps.
-        AsyncIO.ForceDotNet.Force();
+        builder.Services.AddSingleton(Random.Shared);
+        builder.Services.AddSingleton<IMeasurementGenerator, MeasurementGenerator>();
+        builder.Services.AddHostedService<AgentPublisher>();
 
-        try
-        {
-            using var pub = new PublisherSocket();
-            pub.Connect(PubConnect);
+        builder.Logging.SetMinimumLevel(LogLevel.Information);
 
-            var rnd = new Random();
-            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(100)); // ~10 Hz per metric
-
-            while (await timer.WaitForNextTickAsync(cts.Token))
-            {
-                var now = DateTime.UtcNow;
-                double t = now.Ticks / 2e7; // slow varying angle
-
-                foreach (var inst in Instruments)
-                    foreach (var met in Metrics)
-                    {
-                        var key = new MeasureKey(inst, met);
-                        double val = met switch
-                        {
-                            "Power" => 10 + 2 * Math.Sin(t) + rnd.NextDouble(),
-                            "SNR" => 30 + 5 * Math.Cos(t) + rnd.NextDouble(),
-                            _ => rnd.NextDouble()
-                        };
-
-                        var m = new Measurement(key, val, now);
-                        var json = JsonSerializer.Serialize(m, JsonOpts);
-
-                        // topic + payload
-                        var msg = new NetMQMessage(2);
-                        msg.Append(TopicMeasure);
-                        msg.Append(json);
-                        pub.SendMultipartMessage(msg);
-                    }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // graceful shutdown
-        }
-        finally
-        {
-            NetMQConfig.Cleanup();
-            Console.WriteLine("Agent: stopped.");
-        }
+        using var host = builder.Build();
+        await host.RunAsync().ConfigureAwait(false);
     }
-
-    public readonly record struct MeasureKey(string InstrumentId, string Metric)
-    {
-        public override string ToString() => $"{InstrumentId}:{Metric}";
-    }
-
-    public sealed record Measurement(MeasureKey Key, double Value, DateTime TimestampUtc);
 }

--- a/EquipmentHubDemo/Agent/appsettings.json
+++ b/EquipmentHubDemo/Agent/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Agent": {
+    "PublishEndpoint": "tcp://127.0.0.1:5556",
+    "Topic": "measure",
+    "PublishIntervalMilliseconds": 100,
+    "SendRetryCount": 3,
+    "SendRetryBackoffMilliseconds": 100,
+    "Instruments": [
+      {
+        "InstrumentId": "UXG-01",
+        "Metrics": [ "Power", "SNR" ]
+      },
+      {
+        "InstrumentId": "UXG-02",
+        "Metrics": [ "Power", "SNR" ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- host the agent publisher inside the generic host with structured logging, retries, and DI
- externalize publish endpoints, topics, and instrument catalogs into strongly-typed options backed by appsettings.json
- extract measurement generation into a dedicated service and update unit tests with additional coverage

## Testing
- dotnet test EquipmentHubDemo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d608e46218832cbcf023a8d6dd8056