### PR TITLE
Propagate cancellation token to polling fetch

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
@@ -148,7 +148,7 @@
                     var batch = await Http.GetFromJsonAsync<List<PointDto>>(url, new System.Text.Json.JsonSerializerOptions
                     {
                         PropertyNameCaseInsensitive = true
-                    });
+                    }, ct);
 
                     if (batch is null || batch.Count == 0)
                     {


### PR DESCRIPTION
## Summary
- forward the polling cancellation token to the HTTP JSON fetch so the loop can cancel promptly

## Testing
- dotnet build EquipmentHubDemo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d60b665944832c838a392b579eacc9