### PR TITLE
Ensure live chart updates without manual refresh

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
 using System.Net;
+using System.Reflection;
 using System.Text;
 using Bunit;
 using EquipmentHubDemo.Components.Pages;
+using EquipmentHubDemo.Domain;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -17,7 +20,7 @@ public sealed class HomePageTests : TestContext
         var handler = new StubHttpMessageHandler();
         handler.RegisterJsonResponse("http://localhost/api/keys", "[\"Line A\"]");
         handler.RegisterJsonResponse(
-            "http://localhost/api/live?key=Line%20A&sinceTicks=0",
+            "http://localhost/api/live?key=Line A&sinceTicks=0",
             "[{\"x\":\"2024-01-01T00:00:00Z\",\"y\":1.5}]");
 
         var httpClient = new HttpClient(handler)
@@ -42,6 +45,50 @@ public sealed class HomePageTests : TestContext
         }, timeout: TimeSpan.FromSeconds(1));
     }
 
+    [Fact]
+    public void Home_RendersChartIsland_WhenKeysAppearLater()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler();
+        handler.RegisterJsonSequence("http://localhost/api/keys", "[]", "[\"Line A\"]");
+        handler.RegisterJsonResponse(
+            "http://localhost/api/live?key=Line A&sinceTicks=0",
+            "[{\"x\":\"2024-01-01T00:00:00Z\",\"y\":1.5}]");
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost/")
+        };
+
+        Services.AddSingleton<HttpClient>(httpClient);
+        Services.AddSingleton<NavigationManager>(new StubNavigationManager());
+
+        // Act
+        var cut = RenderComponent<Home>();
+
+        var totalField = typeof(Home).GetField("_totalReceived", BindingFlags.Instance | BindingFlags.NonPublic);
+        var pointsField = typeof(Home).GetField("_points", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(totalField);
+        Assert.NotNull(pointsField);
+
+        // Ensure the live endpoint was polled.
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains(handler.RequestedUris, uri => uri.StartsWith("http://localhost/api/live?key=Line A", StringComparison.Ordinal));
+        }, timeout: TimeSpan.FromSeconds(5));
+
+        // Assert - internal state receives live data without manual refresh.
+        cut.WaitForAssertion(() =>
+        {
+            var total = (long)(totalField!.GetValue(cut.Instance) ?? 0L);
+            var points = (List<PointDto>?)pointsField!.GetValue(cut.Instance);
+
+            Assert.True(total > 0, "total measurements should increase");
+            Assert.NotNull(points);
+            Assert.True(points!.Count > 0, "chart points should be populated");
+        }, timeout: TimeSpan.FromSeconds(5));
+    }
+
     private sealed class StubNavigationManager : NavigationManager
     {
         public StubNavigationManager()
@@ -57,19 +104,32 @@ public sealed class HomePageTests : TestContext
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
-        private readonly Dictionary<string, string> _responses = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Queue<string>> _responses = new(StringComparer.OrdinalIgnoreCase);
+        public List<string> RequestedUris { get; } = new();
 
         public void RegisterJsonResponse(string url, string json)
         {
-            _responses[url] = json;
+            _responses[url] = new Queue<string>(new[] { json });
+        }
+
+        public void RegisterJsonSequence(string url, params string[] json)
+        {
+            if (json.Length == 0)
+            {
+                throw new ArgumentException("Sequence must contain at least one entry.", nameof(json));
+            }
+
+            _responses[url] = new Queue<string>(json);
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var uri = request.RequestUri?.ToString() ?? string.Empty;
-            if (_responses.TryGetValue(uri, out var json))
+            RequestedUris.Add(uri);
+            if (_responses.TryGetValue(uri, out var queue))
             {
-                return Task.FromResult(CreateJsonResponse(json));
+                var payload = queue.Count > 1 ? queue.Dequeue() : queue.Peek();
+                return Task.FromResult(CreateJsonResponse(payload));
             }
 
             if (uri.Contains("/api/live", StringComparison.OrdinalIgnoreCase))

--- a/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/Pages/Home.razor
@@ -41,6 +41,8 @@
 
     private CancellationTokenSource? _cts;
     private Task? _pollingTask;
+    private CancellationTokenSource? _keyRefreshCts;
+    private Task? _keyRefreshTask;
 
     private List<PointDto> _points = new();
     private long _totalReceived;
@@ -52,23 +54,14 @@
     {
         try
         {
-            keys = await Http.GetFromJsonAsync<List<string>>(Api("/api/keys")) ?? new();
-            if (keys.Count == 0)
-            {
-                error = "No keys yet. Is the Agent running and the broker/worker receiving data?";
-                return;
-            }
-
-            selectedKey = keys[0];
-            if (running)
-            {
-                await StartPollingAsync();
-            }
+            await TryLoadKeysAsync(initialLoad: true);
         }
         catch (Exception ex)
         {
             error = "Init failed: " + ex.Message;
         }
+
+        EnsureKeyRefreshLoop();
     }
 
     private async Task ToggleAsync()
@@ -211,5 +204,170 @@
     public async ValueTask DisposeAsync()
     {
         await StopPollingAsync();
+        await StopKeyRefreshLoopAsync();
+    }
+
+    private async Task<bool> TryLoadKeysAsync(bool initialLoad)
+    {
+        var latest = await Http.GetFromJsonAsync<List<string>>(Api("/api/keys")) ?? new();
+
+        keys = latest;
+        if (keys.Count == 0)
+        {
+            await StopPollingAsync();
+            error = "Waiting for live data…";
+            _points = new List<PointDto>();
+            _sinceTicks = 0;
+            _totalReceived = 0;
+            StateHasChanged();
+            return false;
+        }
+
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(selectedKey) || !keys.Contains(selectedKey))
+        {
+            selectedKey = keys[0];
+        }
+
+        if (!running)
+        {
+            StateHasChanged();
+            return true;
+        }
+
+        if (initialLoad || _points.Count == 0)
+        {
+            await StartPollingAsync();
+        }
+
+        return true;
+    }
+
+    private void EnsureKeyRefreshLoop()
+    {
+        if (_keyRefreshTask is not null)
+        {
+            return;
+        }
+
+        _keyRefreshCts = new CancellationTokenSource();
+        _keyRefreshTask = RefreshKeysLoopAsync(_keyRefreshCts.Token);
+    }
+
+    private async Task RefreshKeysLoopAsync(CancellationToken ct)
+    {
+        var delay = TimeSpan.FromSeconds(2);
+        var firstIteration = true;
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                if (!firstIteration)
+                {
+                    await Task.Delay(delay, ct);
+                }
+                firstIteration = false;
+
+                List<string> latest;
+                try
+                {
+                    latest = await Http.GetFromJsonAsync<List<string>>(Api("/api/keys"), ct) ?? new();
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    await InvokeAsync(() =>
+                    {
+                        error = "Key refresh failed: " + ex.Message;
+                        StateHasChanged();
+                    });
+                    continue;
+                }
+
+                await InvokeAsync(async () =>
+                {
+                    var previousKeys = keys;
+                    var previousSelection = selectedKey;
+                    var hadKeysBefore = previousKeys.Count > 0;
+
+                    keys = latest;
+
+                    if (keys.Count == 0)
+                    {
+                        if (hadKeysBefore)
+                        {
+                            await StopPollingAsync();
+                        }
+
+                        error = "Waiting for live data…";
+                        _points = new List<PointDto>();
+                        _sinceTicks = 0;
+                        _totalReceived = 0;
+                        StateHasChanged();
+                        return;
+                    }
+
+                    error = null;
+
+                    if (string.IsNullOrWhiteSpace(selectedKey) || !keys.Contains(selectedKey))
+                    {
+                        selectedKey = keys[0];
+                    }
+
+                    var selectionChanged = !string.Equals(previousSelection, selectedKey, StringComparison.Ordinal);
+
+                    if (running && (selectionChanged || !hadKeysBefore))
+                    {
+                        await StartPollingAsync();
+                    }
+                    else
+                    {
+                        StateHasChanged();
+                    }
+                });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // loop cancelled -> exit silently
+        }
+        finally
+        {
+            await InvokeAsync(() =>
+            {
+                _keyRefreshTask = null;
+                _keyRefreshCts?.Dispose();
+                _keyRefreshCts = null;
+            });
+        }
+    }
+
+    private async Task StopKeyRefreshLoopAsync()
+    {
+        if (_keyRefreshTask is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _keyRefreshCts?.Cancel();
+            await _keyRefreshTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on cancellation
+        }
+        finally
+        {
+            _keyRefreshCts?.Dispose();
+            _keyRefreshCts = null;
+            _keyRefreshTask = null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a background key refresh loop so the Home page starts polling automatically when live data arrives and keeps the UI state in sync
- reset the chart/counter state when keys disappear and restart polling when they reappear to avoid requiring browser refreshes
- extend the Home page bUnit tests with richer HTTP stubs to cover late-arriving keys and verify live data propagation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68d60a9b9d50832ca58290895452b038