### PR TITLE
Add regression tests for router shared component configuration

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo.Client/Routes.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/Routes.razor
@@ -1,4 +1,5 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
+<Router AppAssembly="typeof(Program).Assembly"
+        AdditionalAssemblies="new[] { typeof(EquipmentHubDemo.Components.Pages.Home).Assembly }">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(EquipmentHubDemo.Components.Layout.MainLayout)" />
         <FocusOnNavigate RouteData="routeData" Selector="h1" />

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/EquipmentHubDemo.Components.Tests.csproj
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/EquipmentHubDemo.Components.Tests.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EquipmentHubDemo.Components\EquipmentHubDemo.Components.csproj" />
+    <ProjectReference Include="..\EquipmentHubDemo.Client\EquipmentHubDemo.Client.csproj" />
+    <ProjectReference Include="..\EquipmentHubDemo\EquipmentHubDemo.csproj" />
     <ProjectReference Include="..\EquipmentHubDemo.Domain\EquipmentHubDemo.Domain.csproj" />
   </ItemGroup>
 

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/RouterConfigurationTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/RouterConfigurationTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Bunit;
+using EquipmentHubDemo.Components.Pages;
+using Microsoft.AspNetCore.Components.Routing;
+using Xunit;
+
+namespace EquipmentHubDemo.Components.Tests;
+
+public sealed class RouterConfigurationTests : TestContext
+{
+    [Fact]
+    public void AppRouter_IncludesSharedComponentsAssembly()
+    {
+        JSInterop.Setup<string>("Blazor._internal.PageTitle.getAndRemoveExistingTitle").SetResult(string.Empty);
+
+        // Act
+        var cut = RenderComponent<EquipmentHubDemo.Components.App>();
+
+        // Assert
+        var router = cut.FindComponent<Router>();
+        var additionalAssemblies = router.Instance.AdditionalAssemblies ?? Array.Empty<Assembly>();
+
+        Assert.Contains(typeof(Home).Assembly, additionalAssemblies);
+    }
+
+    [Fact]
+    public void ClientRouter_IncludesSharedComponentsAssembly()
+    {
+        JSInterop.Setup<string>("Blazor._internal.PageTitle.getAndRemoveExistingTitle").SetResult(string.Empty);
+
+        // Act
+        var cut = RenderComponent<EquipmentHubDemo.Client.Routes>();
+
+        // Assert
+        var router = cut.FindComponent<Router>();
+        var additionalAssemblies = router.Instance.AdditionalAssemblies ?? Array.Empty<Assembly>();
+
+        Assert.Contains(typeof(Home).Assembly, additionalAssemblies);
+    }
+}

--- a/EquipmentHubDemo/EquipmentHubDemo/Components/App.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo/Components/App.razor
@@ -1,4 +1,5 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
+<Router AppAssembly="@typeof(App).Assembly"
+        AdditionalAssemblies="new[] { typeof(EquipmentHubDemo.Components.Pages.Home).Assembly }">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />


### PR DESCRIPTION
## Summary
- add regression tests to ensure both server and WebAssembly routers include the shared components assembly
- reference the server and client projects from the component test project so the routers can be rendered in bUnit

## Testing
- dotnet test EquipmentHubDemo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d6bb305274832ca1da10981369ea4c