### PR TITLE
Improve live data client integration

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo.Client/Program.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/Program.cs
@@ -1,15 +1,23 @@
 using EquipmentHubDemo.Client;
+using EquipmentHubDemo.Client.Services;
+using EquipmentHubDemo.Domain.Live;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Configuration;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.RootComponents.Add<Routes>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
+builder.Services.Configure<ApiClientOptions>(options =>
+    builder.Configuration.GetSection(ApiClientOptions.SectionName).Bind(options));
+
 builder.Services.AddScoped(sp => new HttpClient
 {
     BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
 });
+
+builder.Services.AddScoped<ILiveMeasurementClient, HttpLiveMeasurementClient>();
 
 await builder.Build().RunAsync();

--- a/EquipmentHubDemo/EquipmentHubDemo.Client/Services/ApiClientOptions.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/Services/ApiClientOptions.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace EquipmentHubDemo.Client.Services;
+
+/// <summary>
+/// Configuration options for resolving the EquipmentHub server API endpoint.
+/// </summary>
+public sealed class ApiClientOptions
+{
+    public const string SectionName = "ApiClient";
+
+    /// <summary>
+    /// Optional list of base addresses (absolute URLs) that will be probed in order when contacting the server.
+    /// </summary>
+    public IList<string> BaseAddresses { get; init; } = new List<string>();
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Client/Services/HttpLiveMeasurementClient.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/Services/HttpLiveMeasurementClient.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using EquipmentHubDemo.Domain;
+using EquipmentHubDemo.Domain.Live;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+
+namespace EquipmentHubDemo.Client.Services;
+
+/// <summary>
+/// HTTP-based implementation of <see cref="ILiveMeasurementClient"/> that can probe multiple candidate endpoints.
+/// </summary>
+public sealed class HttpLiveMeasurementClient : ILiveMeasurementClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly IReadOnlyList<Uri> _candidateBaseUris;
+    private Uri? _preferredBaseUri;
+
+    public HttpLiveMeasurementClient(
+        HttpClient httpClient,
+        IOptions<ApiClientOptions> options,
+        NavigationManager navigationManager)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        ArgumentNullException.ThrowIfNull(navigationManager);
+
+        var unique = new List<Uri>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void TryAdd(Uri? candidate)
+        {
+            if (candidate is null)
+            {
+                return;
+            }
+
+            var normalized = EnsureTrailingSlash(candidate.AbsoluteUri);
+            if (seen.Add(normalized))
+            {
+                unique.Add(new Uri(normalized, UriKind.Absolute));
+            }
+        }
+
+        if (options?.Value?.BaseAddresses is { Count: > 0 } configured)
+        {
+            foreach (var address in configured)
+            {
+                if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
+                {
+                    TryAdd(uri);
+                }
+            }
+        }
+
+        if (unique.Count == 0)
+        {
+            if (Uri.TryCreate(navigationManager.BaseUri, UriKind.Absolute, out var navBase))
+            {
+                TryAdd(navBase);
+            }
+            else if (httpClient.BaseAddress is not null)
+            {
+                TryAdd(httpClient.BaseAddress);
+            }
+        }
+
+        if (unique.Count == 0)
+        {
+            throw new ArgumentException(
+                "No valid API base addresses were configured for the live measurement client.",
+                nameof(options));
+        }
+
+        _candidateBaseUris = unique;
+    }
+
+    public async Task<IReadOnlyList<string>> GetAvailableKeysAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await FetchListAsync<string>("api/keys", cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    public async Task<IReadOnlyList<PointDto>> GetMeasurementsAsync(string key, long sinceTicks, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
+        }
+
+        if (sinceTicks < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sinceTicks), sinceTicks, "sinceTicks must be non-negative.");
+        }
+
+        var relativePath = $"api/live?key={Uri.EscapeDataString(key)}&sinceTicks={sinceTicks}";
+        return await FetchListAsync<PointDto>(relativePath, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<TElement>> FetchListAsync<TElement>(string relativePath, CancellationToken cancellationToken)
+    {
+        var errors = new List<string>();
+
+        foreach (var baseUri in EnumerateBaseUris())
+        {
+            var requestUri = new Uri(baseUri, relativePath);
+
+            try
+            {
+                using var response = await _httpClient.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var payload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    errors.Add($"[{requestUri}] HTTP {(int)response.StatusCode} ({response.ReasonPhrase})");
+                    continue;
+                }
+
+                if (!IsJsonPayload(response.Content.Headers.ContentType, payload))
+                {
+                    var mediaType = response.Content.Headers.ContentType?.MediaType ?? "unknown";
+                    errors.Add($"[{requestUri}] Non-JSON payload (Content-Type '{mediaType}', Body '{Preview(payload)}')");
+                    continue;
+                }
+
+                try
+                {
+                    var deserialized = JsonSerializer.Deserialize<List<TElement>>(payload, SerializerOptions) ?? new List<TElement>();
+                    Volatile.Write(ref _preferredBaseUri, baseUri);
+                    return deserialized;
+                }
+                catch (JsonException ex)
+                {
+                    errors.Add($"[{requestUri}] JSON parse error: {ex.Message}");
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                errors.Add($"[{requestUri}] {ex.Message}");
+            }
+        }
+
+        throw new LiveMeasurementClientException(BuildAggregateError(relativePath, errors));
+    }
+
+    private IEnumerable<Uri> EnumerateBaseUris()
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var preferred = Volatile.Read(ref _preferredBaseUri);
+        if (preferred is not null && visited.Add(preferred.AbsoluteUri))
+        {
+            yield return preferred;
+        }
+
+        foreach (var candidate in _candidateBaseUris)
+        {
+            if (visited.Add(candidate.AbsoluteUri))
+            {
+                yield return candidate;
+            }
+        }
+    }
+
+    private static bool IsJsonPayload(MediaTypeHeaderValue? contentType, string payload)
+    {
+        if (contentType is not null && !string.IsNullOrWhiteSpace(contentType.MediaType))
+        {
+            return contentType.MediaType.Contains("json", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return true;
+        }
+
+        var trimmed = payload.TrimStart();
+        return trimmed.StartsWith("{", StringComparison.Ordinal) || trimmed.StartsWith("[", StringComparison.Ordinal);
+    }
+
+    private static string Preview(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.ReplaceLineEndings(" ").Trim();
+        const int maxLength = 120;
+        if (normalized.Length <= maxLength)
+        {
+            return normalized;
+        }
+
+        return normalized[..maxLength] + "…";
+    }
+
+    private static string BuildAggregateError(string relativePath, IReadOnlyList<string> errors)
+    {
+        if (errors.Count == 0)
+        {
+            return $"No API endpoints were reachable for '{relativePath}'.";
+        }
+
+        var builder = new StringBuilder();
+        builder.Append($"Unable to retrieve '{relativePath}'. Attempted endpoints: ");
+        builder.Append(string.Join("; ", errors));
+        return builder.ToString();
+    }
+
+    private static string EnsureTrailingSlash(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        return value.EndsWith("/", StringComparison.Ordinal) ? value : value + "/";
+    }
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/appsettings.Development.json
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ApiClient": {
+    "BaseAddresses": [
+      "https://localhost:7118/",
+      "http://localhost:5026/"
+    ]
   }
 }

--- a/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/appsettings.json
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ApiClient": {
+    "BaseAddresses": []
   }
 }

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HttpLiveMeasurementClientTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HttpLiveMeasurementClientTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EquipmentHubDemo.Client.Services;
+using EquipmentHubDemo.Domain.Live;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace EquipmentHubDemo.Components.Tests;
+
+public sealed class HttpLiveMeasurementClientTests
+{
+    [Fact]
+    public async Task GetAvailableKeysAsync_FallsBackToNextBaseAddress()
+    {
+        // Arrange
+        var handler = new SequenceMessageHandler();
+        handler.Register(
+            "https://client/api/keys",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html>client host</html>", Encoding.UTF8, "text/html")
+            });
+        handler.Register(
+            "https://server/api/keys",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[\"Line A\"]", Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new ApiClientOptions
+        {
+            BaseAddresses = new List<string> { "https://client", "https://server" }
+        });
+        var navigation = new TestNavigationManager("https://client/");
+
+        var client = new HttpLiveMeasurementClient(httpClient, options, navigation);
+
+        // Act
+        var keys = await client.GetAvailableKeysAsync();
+
+        // Assert
+        Assert.Equal(new[] { "Line A" }, keys);
+        Assert.Equal(
+            new[] { "https://client/api/keys", "https://server/api/keys" },
+            handler.RequestedUris);
+    }
+
+    [Fact]
+    public async Task GetAvailableKeysAsync_WhenNonJson_ThrowsMeaningfulException()
+    {
+        // Arrange
+        var handler = new SequenceMessageHandler();
+        handler.Register(
+            "https://client/api/keys",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html>not json</html>", Encoding.UTF8, "text/html")
+            });
+
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new ApiClientOptions
+        {
+            BaseAddresses = new List<string> { "https://client" }
+        });
+        var navigation = new TestNavigationManager("https://client/");
+
+        var client = new HttpLiveMeasurementClient(httpClient, options, navigation);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<LiveMeasurementClientException>(() => client.GetAvailableKeysAsync());
+
+        // Assert
+        Assert.Contains("Non-JSON payload", ex.Message);
+        Assert.DoesNotContain("invalid start of a value", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetMeasurementsAsync_ReturnsPoints()
+    {
+        // Arrange
+        var handler = new SequenceMessageHandler();
+        handler.Register(
+            "https://server/api/live?key=Line%20A&sinceTicks=0",
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "[{\"x\":\"2024-01-01T00:00:00Z\",\"y\":2.5}]",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new ApiClientOptions
+        {
+            BaseAddresses = new List<string> { "https://server" }
+        });
+        var navigation = new TestNavigationManager("https://server/");
+
+        var client = new HttpLiveMeasurementClient(httpClient, options, navigation);
+
+        // Act
+        var points = await client.GetMeasurementsAsync("Line A", 0);
+
+        // Assert
+        var point = Assert.Single(points);
+        Assert.Equal(2.5, point.Y);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), point.X);
+    }
+
+    private sealed class TestNavigationManager : NavigationManager
+    {
+        public TestNavigationManager(string baseUri)
+        {
+            Initialize(baseUri, baseUri);
+        }
+
+        protected override void NavigateToCore(string uri, bool forceLoad)
+        {
+            // Navigation is not required for tests.
+        }
+    }
+
+    private sealed class SequenceMessageHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, Queue<HttpResponseMessage>> _responses = new(StringComparer.Ordinal);
+        public List<string> RequestedUris { get; } = new();
+
+        public void Register(string absoluteUrl, HttpResponseMessage response)
+        {
+            var key = Normalize(absoluteUrl);
+
+            if (!_responses.TryGetValue(key, out var queue))
+            {
+                queue = new Queue<HttpResponseMessage>();
+                _responses[key] = queue;
+            }
+
+            queue.Enqueue(response);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.AbsoluteUri ?? string.Empty;
+            RequestedUris.Add(uri);
+
+            var key = Normalize(uri);
+
+            if (_responses.TryGetValue(key, out var queue) && queue.Count > 0)
+            {
+                return Task.FromResult(queue.Dequeue());
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static string Normalize(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            return new Uri(value, UriKind.Absolute).AbsoluteUri;
+        }
+    }
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/RouterConfigurationTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/RouterConfigurationTests.cs
@@ -1,13 +1,23 @@
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Bunit;
 using EquipmentHubDemo.Components.Pages;
+using EquipmentHubDemo.Domain;
+using EquipmentHubDemo.Domain.Live;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EquipmentHubDemo.Components.Tests;
 
 public sealed class RouterConfigurationTests : TestContext
 {
+    public RouterConfigurationTests()
+    {
+        Services.AddSingleton<ILiveMeasurementClient>(new NoopLiveMeasurementClient());
+    }
+
     [Fact]
     public void AppRouter_IncludesSharedComponentsAssembly()
     {
@@ -36,5 +46,14 @@ public sealed class RouterConfigurationTests : TestContext
         var additionalAssemblies = router.Instance.AdditionalAssemblies ?? Array.Empty<Assembly>();
 
         Assert.Contains(typeof(Home).Assembly, additionalAssemblies);
+    }
+
+    private sealed class NoopLiveMeasurementClient : ILiveMeasurementClient
+    {
+        public Task<IReadOnlyList<string>> GetAvailableKeysAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+
+        public Task<IReadOnlyList<PointDto>> GetMeasurementsAsync(string key, long sinceTicks, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PointDto>>(Array.Empty<PointDto>());
     }
 }

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
@@ -4,8 +4,7 @@
 @rendermode InteractiveWebAssembly
 @namespace EquipmentHubDemo.Components.Pages
 
-@inject HttpClient Http
-@inject NavigationManager Nav
+@inject ILiveMeasurementClient Measurements
 
 <h3>Live Measurements</h3>
 <p class="text-muted">Agent → Broker → Filter/Store → Live cache → (WASM UI)</p>
@@ -47,8 +46,6 @@
     private List<PointDto> _points = new();
     private long _totalReceived;
     private long _sinceTicks;
-
-    private string Api(string relative) => Nav.ToAbsoluteUri(relative).ToString();
 
     protected override async Task OnInitializedAsync()
     {
@@ -137,11 +134,7 @@
 
                 try
                 {
-                    var url = Api($"/api/live?key={Uri.EscapeDataString(key)}&sinceTicks={_sinceTicks}");
-                    var batch = await Http.GetFromJsonAsync<List<PointDto>>(url, new System.Text.Json.JsonSerializerOptions
-                    {
-                        PropertyNameCaseInsensitive = true
-                    }, ct);
+                    var batch = await Measurements.GetMeasurementsAsync(key, _sinceTicks, ct);
 
                     if (batch is null || batch.Count == 0)
                     {
@@ -214,7 +207,8 @@
 
     private async Task<bool> TryLoadKeysAsync(bool initialLoad)
     {
-        var latest = await Http.GetFromJsonAsync<List<string>>(Api("/api/keys")) ?? new();
+        var latestKeys = await Measurements.GetAvailableKeysAsync();
+        var latest = latestKeys is null ? new List<string>() : new List<string>(latestKeys);
 
         keys = latest;
         if (keys.Count == 0)
@@ -278,7 +272,8 @@
                 List<string> latest;
                 try
                 {
-                    latest = await Http.GetFromJsonAsync<List<string>>(Api("/api/keys"), ct) ?? new();
+                    var refreshedKeys = await Measurements.GetAvailableKeysAsync(ct);
+                    latest = refreshedKeys is null ? new List<string>() : new List<string>(refreshedKeys);
                 }
                 catch (OperationCanceledException)
                 {

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/_Imports.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/_Imports.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using EquipmentHubDemo.Domain
+@using EquipmentHubDemo.Domain.Live
 @using LiveChartsCore
 @using LiveChartsCore.SkiaSharpView
 @using LiveChartsCore.SkiaSharpView.Blazor

--- a/EquipmentHubDemo/EquipmentHubDemo.Domain/Live/ILiveMeasurementClient.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Domain/Live/ILiveMeasurementClient.cs
@@ -1,0 +1,25 @@
+using EquipmentHubDemo.Domain;
+
+namespace EquipmentHubDemo.Domain.Live;
+
+/// <summary>
+/// Defines the contract for retrieving live measurement metadata and data points.
+/// </summary>
+public interface ILiveMeasurementClient
+{
+    /// <summary>
+    /// Retrieves the list of available measurement keys that can be charted.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A read-only list of measurement keys.</returns>
+    Task<IReadOnlyList<string>> GetAvailableKeysAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the live data points for a given measurement key.
+    /// </summary>
+    /// <param name="key">The measurement identifier.</param>
+    /// <param name="sinceTicks">Only points with a timestamp greater than this tick count will be returned.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A read-only list of measurement points ordered by timestamp.</returns>
+    Task<IReadOnlyList<PointDto>> GetMeasurementsAsync(string key, long sinceTicks, CancellationToken cancellationToken = default);
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Domain/Live/LiveMeasurementClientException.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Domain/Live/LiveMeasurementClientException.cs
@@ -1,0 +1,17 @@
+namespace EquipmentHubDemo.Domain.Live;
+
+/// <summary>
+/// Represents errors that occur when retrieving live measurements from an API endpoint.
+/// </summary>
+public sealed class LiveMeasurementClientException : Exception
+{
+    public LiveMeasurementClientException(string message)
+        : base(message)
+    {
+    }
+
+    public LiveMeasurementClientException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/EquipmentHubDemo/EquipmentHubDemo/Program.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo/Program.cs
@@ -1,5 +1,8 @@
 using EquipmentHubDemo.Components;
+using EquipmentHubDemo.Client.Services;
 using EquipmentHubDemo.Domain;
+using EquipmentHubDemo.Domain.Live;
+using Microsoft.Extensions.Configuration;
 using EquipmentHubDemo.Infrastructure;
 using EquipmentHubDemo.Live;
 using EquipmentHubDemo.Workers;
@@ -17,6 +20,9 @@ builder.Services.AddAntiforgery();
 
 // Optional: server-side HttpClient (WASM gets its own automatically)
 builder.Services.AddHttpClient();
+builder.Services.Configure<ApiClientOptions>(options =>
+    builder.Configuration.GetSection(ApiClientOptions.SectionName).Bind(options));
+builder.Services.AddScoped<ILiveMeasurementClient, HttpLiveMeasurementClient>();
 
 // Infra + services
 builder.Services.AddSingleton<IMeasurementRepository>(sp =>


### PR DESCRIPTION
## Summary
- add a configurable HttpLiveMeasurementClient with shared options so the WASM UI can reach the EquipmentHub server reliably
- update Home page to consume ILiveMeasurementClient, adjust configuration defaults, and register the client on both hosts
- expand automated coverage with new HttpLiveMeasurementClient tests and updated component tests to guard the integration path

## Testing
- dotnet test EquipmentHubDemo.sln

------
https://chatgpt.com/codex/tasks/task_e_68d6e1800b84832c8ba4649f30936207