### PR TITLE
Allow dynamic loopback origins for CORS

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo/appsettings.json
+++ b/EquipmentHubDemo/EquipmentHubDemo/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "LiveCache": {
     "MaxPointsPerKey": 2000
   },


### PR DESCRIPTION
## Summary
- allow the DevClient CORS policy to accept loopback origins discovered at runtime and additional hosts from configuration
- apply the policy in the middleware pipeline so minimal APIs emit the appropriate CORS headers

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d7029cd7c4832cb65c055bfca73102