### PR TITLE
Simplify DevClient CORS policy configuration

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo/appsettings.json
+++ b/EquipmentHubDemo/EquipmentHubDemo/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "LiveCache": {
     "MaxPointsPerKey": 2000
   },


### PR DESCRIPTION
## Summary
- register the DevClient CORS policy with explicit development origins and optional configuration entries
- keep the policy constrained to GET requests with standard headers while applying it globally to minimal APIs

## Testing
- dotnet build
- dotnet format --verify-no-changes --verbosity minimal

------
https://chatgpt.com/codex/tasks/task_e_68d7029cd7c4832cb65c055bfca73102