### PR TITLE
Switch agent telemetry to temperature, humidity, and power metrics

### DIFF
--- a/EquipmentHubDemo/Agent.Tests/ProgramTests.cs
+++ b/EquipmentHubDemo/Agent.Tests/ProgramTests.cs
@@ -22,7 +22,7 @@ public static class ProgramTests
     public static void Measurement_WithExpression_CreatesUpdatedCopy()
     {
         var timestamp = new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Utc);
-        var key = new MeasureKey("UXG-42", "Power");
+        var key = new MeasureKey("UXG-42", "Power (240VAC)");
         var measurement = new Measurement(key, 10.5, timestamp);
 
         var updated = measurement with { Value = 12.3 };
@@ -38,7 +38,7 @@ public static class ProgramTests
     {
         var timestamp = new DateTime(2024, 05, 06, 07, 08, 09, DateTimeKind.Utc);
         var measurement = new Measurement(
-            new MeasureKey("UXG-11", "SNR"),
+            new MeasureKey("UXG-11", "Humidity"),
             42.1,
             timestamp);
 
@@ -47,7 +47,7 @@ public static class ProgramTests
 
         Assert.True(root.TryGetProperty("key", out var keyElement));
         Assert.Equal("UXG-11", keyElement.GetProperty("instrumentId").GetString());
-        Assert.Equal("SNR", keyElement.GetProperty("metric").GetString());
+        Assert.Equal("Humidity", keyElement.GetProperty("metric").GetString());
         Assert.Equal(42.1, root.GetProperty("value").GetDouble());
         Assert.Equal(timestamp, root.GetProperty("timestampUtc").GetDateTime().ToUniversalTime());
     }
@@ -62,12 +62,12 @@ public static class ProgramTests
                 new()
                 {
                     InstrumentId = "A-01",
-                    Metrics = new List<string> { "Power" }
+                    Metrics = new List<string> { "Power (240VAC)" }
                 },
                 new()
                 {
                     InstrumentId = "B-02",
-                    Metrics = new List<string> { "SNR", "Custom" }
+                    Metrics = new List<string> { "Humidity", "Custom" }
                 }
             }
         });
@@ -79,8 +79,9 @@ public static class ProgramTests
         var results = generator.CreateMeasurements(timestamp).ToList();
 
         Assert.Equal(3, results.Count);
-        Assert.Contains(results, m => m.Key.InstrumentId == "A-01" && m.Key.Metric == "Power");
-        Assert.Contains(results, m => m.Key.InstrumentId == "B-02" && m.Key.Metric == "SNR");
+        Assert.Contains(results, m => m.Key.InstrumentId == "A-01" && m.Key.Metric == "Power (240VAC)"
+            && m.Value != default);
+        Assert.Contains(results, m => m.Key.InstrumentId == "B-02" && m.Key.Metric == "Humidity");
         Assert.Contains(results, m => m.Key.InstrumentId == "B-02" && m.Key.Metric == "Custom");
     }
 }

--- a/EquipmentHubDemo/Agent/AgentOptions.cs
+++ b/EquipmentHubDemo/Agent/AgentOptions.cs
@@ -76,12 +76,12 @@ public sealed class AgentOptions
             new InstrumentOptions
             {
                 InstrumentId = "UXG-01",
-                Metrics = new List<string> { "Power", "SNR" }
+                Metrics = new List<string> { "Temperature", "Humidity", "Power (240VAC)" }
             },
             new InstrumentOptions
             {
                 InstrumentId = "UXG-02",
-                Metrics = new List<string> { "Power", "SNR" }
+                Metrics = new List<string> { "Temperature", "Humidity", "Power (240VAC)" }
             }
         };
 }

--- a/EquipmentHubDemo/Agent/MeasurementGenerator.cs
+++ b/EquipmentHubDemo/Agent/MeasurementGenerator.cs
@@ -42,14 +42,19 @@ internal sealed class MeasurementGenerator : IMeasurementGenerator
 
     private double GenerateValue(string metric, double angle)
     {
-        if (string.Equals(metric, "Power", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(metric, "Temperature", StringComparison.OrdinalIgnoreCase))
         {
-            return 10 + 2 * Math.Sin(angle) + _random.NextDouble();
+            return 22 + 5 * Math.Sin(angle) + 0.5 * _random.NextDouble();
         }
 
-        if (string.Equals(metric, "SNR", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(metric, "Humidity", StringComparison.OrdinalIgnoreCase))
         {
-            return 30 + 5 * Math.Cos(angle) + _random.NextDouble();
+            return 45 + 15 * Math.Cos(angle) + _random.NextDouble();
+        }
+
+        if (string.Equals(metric, "Power (240VAC)", StringComparison.OrdinalIgnoreCase))
+        {
+            return 240 + 5 * Math.Sin(angle) + 2 * _random.NextDouble();
         }
 
         return GenerateFallbackValue(metric);

--- a/EquipmentHubDemo/Agent/appsettings.json
+++ b/EquipmentHubDemo/Agent/appsettings.json
@@ -8,11 +8,11 @@
     "Instruments": [
       {
         "InstrumentId": "UXG-01",
-        "Metrics": [ "Power", "SNR" ]
+        "Metrics": [ "Temperature", "Humidity", "Power (240VAC)" ]
       },
       {
         "InstrumentId": "UXG-02",
-        "Metrics": [ "Power", "SNR" ]
+        "Metrics": [ "Temperature", "Humidity", "Power (240VAC)" ]
       }
     ]
   }

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/ChartIslandTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/ChartIslandTests.cs
@@ -68,7 +68,7 @@ public sealed class ChartIslandTests : TestContext
         var points = new[] { new PointDto { X = baseTime, Y = 3.5 } };
 
         var cut = RenderComponent<ChartIsland>(parameters => parameters
-            .Add(p => p.Title, "UXG-01:Power")
+            .Add(p => p.Title, "UXG-01:Temperature")
             .Add(p => p.Points, points));
 
         var xAxesField = typeof(ChartIsland).GetField("xAxes", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -77,14 +77,14 @@ public sealed class ChartIslandTests : TestContext
         var yAxes = Assert.IsAssignableFrom<Axis[]>(yAxesField?.GetValue(cut.Instance));
 
         Assert.Equal("UXG-01 Time (UTC)", xAxes[0].Name);
-        Assert.Equal("Power (dBm)", yAxes[0].Name);
+        Assert.Equal("Temperature (°C)", yAxes[0].Name);
 
         cut.SetParametersAndRender(parameters => parameters
-            .Add(p => p.Title, "UXG-01:SNR")
+            .Add(p => p.Title, "UXG-01:Humidity")
             .Add(p => p.Points, points));
 
         Assert.Equal("UXG-01 Time (UTC)", xAxes[0].Name);
-        Assert.Equal("Signal-to-Noise Ratio (dB)", yAxes[0].Name);
+        Assert.Equal("Relative Humidity (%)", yAxes[0].Name);
 
         cut.SetParametersAndRender(parameters => parameters
             .Add(p => p.Title, "UXG-02:Voltage")

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/ChartIsland.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/ChartIsland.razor
@@ -53,8 +53,9 @@ else
     private static readonly IReadOnlyDictionary<string, VerticalAxisMetadata> VerticalAxisByMetric =
         new Dictionary<string, VerticalAxisMetadata>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Power"] = new VerticalAxisMetadata("Power (dBm)", FormatWithTwoDecimals),
-            ["SNR"] = new VerticalAxisMetadata("Signal-to-Noise Ratio (dB)", FormatWithOneDecimal)
+            ["Temperature"] = new VerticalAxisMetadata("Temperature (°C)", FormatWithOneDecimal),
+            ["Humidity"] = new VerticalAxisMetadata("Relative Humidity (%)", FormatWithOneDecimal),
+            ["Power (240VAC)"] = new VerticalAxisMetadata("Power (240 VAC)", FormatWithTwoDecimals)
         };
 
     private readonly ObservableCollection<ObservablePoint> _values = new();

--- a/EquipmentHubDemo/EquipmentHubDemo/Program.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo/Program.cs
@@ -133,7 +133,7 @@ app.UseCors("DevClient");
 // ---------- Minimal read APIs for WASM UI ----------
 app.MapGet("/api/keys", (ILiveCache cache) =>
 {
-    // returns: ["UXG-01:Power", "UXG-02:SNR", ...]
+    // returns: ["UXG-01:Temperature", "UXG-01:Humidity", "UXG-01:Power (240VAC)", ...]
     return Results.Json(cache.Keys);
 });
 


### PR DESCRIPTION
## Summary
- update the agent telemetry generator and defaults to publish temperature, humidity, and power (240VAC)
- align chart axis metadata and documentation comments with the new metrics
- refresh unit tests and configuration to validate the new measurement set

## Testing
- `dotnet test EquipmentHubDemo.sln`


------
https://chatgpt.com/codex/tasks/task_e_68d72fc267c0832cb1e7b41478eec7d0