### PR TITLE
Add support for multiple live charts

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
@@ -86,6 +86,38 @@ public sealed class HomePageTests : TestContext
         }, timeout: TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public void Home_RendersUpToThreeChartsByDefault()
+    {
+        // Arrange
+        var measurementClient = new StubLiveMeasurementClient(
+            keysSequence: new[]
+            {
+                new[] { "Line A", "Line B", "Line C", "Line D" }
+            },
+            measurementsSequence: new IReadOnlyList<PointDto>[]
+            {
+                Array.Empty<PointDto>()
+            });
+
+        Services.AddSingleton<ILiveMeasurementClient>(measurementClient);
+
+        // Act
+        var cut = RenderComponent<Home>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var chartIslands = cut.FindComponents<ChartIsland>();
+            Assert.Equal(3, chartIslands.Count);
+
+            var titles = cut.FindAll("h6.card-title").Select(e => e.TextContent.Trim()).ToList();
+            Assert.Contains("Line A", titles);
+            Assert.Contains("Line B", titles);
+            Assert.Contains("Line C", titles);
+        }, timeout: TimeSpan.FromSeconds(2));
+    }
+
     private sealed class StubLiveMeasurementClient : ILiveMeasurementClient
     {
         private readonly Queue<IReadOnlyList<string>> _keys;

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
@@ -1,5 +1,7 @@
 @page "/"
 @using Microsoft.AspNetCore.Components.Web
+@using System.Linq
+@using System.Text
 @implements IAsyncDisposable
 @rendermode InteractiveWebAssembly
 @namespace EquipmentHubDemo.Components.Pages
@@ -14,28 +16,58 @@
     <div class="alert alert-danger">@error</div>
 }
 
-<select value="@selectedKey" @onchange="OnSelectedChanged" class="form-select form-select-sm" style="max-width:460px;">
-    @foreach (var k in keys)
-    {
-        <option value="@k">@k</option>
-    }
-</select>
+<div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+    <div class="flex-grow-1">
+        <div class="d-flex flex-wrap align-items-center gap-3">
+            @foreach (var key in keys)
+            {
+                var checkboxId = CreateCheckboxId(key);
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input"
+                           type="checkbox"
+                           id="@checkboxId"
+                           checked="@IsSelected(key)"
+                           @onchange="async e => await OnKeyToggledAsync(key, e)" />
+                    <label class="form-check-label" for="@checkboxId">@key</label>
+                </div>
+            }
+        </div>
+    </div>
 
-<button class="btn btn-sm btn-primary ms-2" @onclick="ToggleAsync">@((running ? "Pause" : "Run"))</button>
-
-<div class="d-flex flex-wrap align-items-center gap-3 mt-2">
-    <span class="badge bg-primary text-wrap">Measurements received: @_totalReceived</span>
-    <span class="text-muted small">Active buffer: @_points.Count</span>
+    <div class="d-flex align-items-center gap-2">
+        <button class="btn btn-sm btn-primary" @onclick="ToggleAsync">@((running ? "Pause" : "Run"))</button>
+        <span class="badge bg-primary text-wrap">Measurements received: @TotalReceived</span>
+        <span class="text-muted small">Active buffer: @ActiveBufferCount</span>
+    </div>
 </div>
 
-<ChartIsland Points="_points"
-             Title="selectedKey" />
+@if (!string.IsNullOrEmpty(selectionWarning))
+{
+    <div class="alert alert-warning mt-2" role="alert">@selectionWarning</div>
+}
+
+<div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mt-2">
+    @foreach (var stream in GetActiveStreams())
+    {
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title text-muted">@stream.Key</h6>
+                    <ChartIsland Points="stream.Points"
+                                 Title="stream.Key" />
+                </div>
+            </div>
+        </div>
+    }
+</div>
 
 @code {
     private string? error;
 
+    private const int MaxChartsDisplayed = 3;
+
     private List<string> keys = new();
-    private string? selectedKey;
+    private IReadOnlyList<string> _selectedKeys = Array.Empty<string>();
     private bool running = true;
 
     private CancellationTokenSource? _cts;
@@ -43,9 +75,12 @@
     private CancellationTokenSource? _keyRefreshCts;
     private Task? _keyRefreshTask;
 
-    private List<PointDto> _points = new();
-    private long _totalReceived;
-    private long _sinceTicks;
+    private readonly Dictionary<string, ChartStream> _chartStreams = new(StringComparer.Ordinal);
+
+    private string? selectionWarning;
+
+    private long TotalReceived => _chartStreams.Values.Sum(s => s.TotalReceived);
+    private int ActiveBufferCount => _selectedKeys.Sum(key => _chartStreams.TryGetValue(key, out var stream) ? stream.Points.Count : 0);
 
     protected override async Task OnInitializedAsync()
     {
@@ -76,20 +111,17 @@
 
     private async Task StartPollingAsync()
     {
-        var key = selectedKey;
-        if (string.IsNullOrWhiteSpace(key))
+        await StopPollingAsync();
+
+        if (_selectedKeys.Count == 0)
         {
             return;
         }
 
-        await StopPollingAsync();
-
-        _points = new List<PointDto>();
-        _sinceTicks = 0;
-        _totalReceived = 0;
+        ResetStreams();
 
         _cts = new CancellationTokenSource();
-        _pollingTask = PollLoopAsync(key, _cts.Token);
+        _pollingTask = PollLoopAsync(_cts.Token);
         await InvokeAsync(StateHasChanged);
     }
 
@@ -120,7 +152,7 @@
         }
     }
 
-    private async Task PollLoopAsync(string key, CancellationToken ct)
+    private async Task PollLoopAsync(CancellationToken ct)
     {
         try
         {
@@ -134,38 +166,38 @@
 
                 try
                 {
-                    var batch = await Measurements.GetMeasurementsAsync(key, _sinceTicks, ct);
-
-                    if (batch is null || batch.Count == 0)
+                    var keysSnapshot = _selectedKeys;
+                    if (keysSnapshot.Count == 0)
                     {
                         continue;
                     }
 
-                    await InvokeAsync(() =>
+                    var hadUpdates = false;
+
+                    foreach (var key in keysSnapshot)
                     {
-                        var newPoints = 0;
-                        foreach (var p in batch)
+                        if (!_chartStreams.TryGetValue(key, out var stream))
                         {
-                            _points.Add(p);
-                            _sinceTicks = Math.Max(_sinceTicks, p.X.Ticks);
-                            newPoints++;
+                            continue;
                         }
 
-                        const int max = 2000;
-                        if (_points.Count > max)
+                        var batch = await Measurements.GetMeasurementsAsync(key, stream.SinceTicks, ct);
+
+                        if (batch is null || batch.Count == 0)
                         {
-                            var excess = _points.Count - max;
-                            _points.RemoveRange(0, excess);
+                            continue;
                         }
 
-                        if (newPoints == 0)
+                        if (stream.Apply(batch))
                         {
-                            return;
+                            hadUpdates = true;
                         }
+                    }
 
-                        _totalReceived += newPoints;
-                        StateHasChanged();
-                    });
+                    if (hadUpdates)
+                    {
+                        await InvokeAsync(StateHasChanged);
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -180,22 +212,6 @@
         catch (OperationCanceledException)
         {
             // loop cancelled -> exit silently
-        }
-    }
-
-    private async Task OnSelectedChanged(ChangeEventArgs e)
-    {
-        selectedKey = e.Value?.ToString();
-        if (running)
-        {
-            await StartPollingAsync();
-        }
-        else
-        {
-            _points = new List<PointDto>();
-            _sinceTicks = 0;
-            _totalReceived = 0;
-            await InvokeAsync(StateHasChanged);
         }
     }
 
@@ -215,29 +231,26 @@
         {
             await StopPollingAsync();
             error = "Waiting for live data…";
-            _points = new List<PointDto>();
-            _sinceTicks = 0;
-            _totalReceived = 0;
+            _selectedKeys = Array.Empty<string>();
+            _chartStreams.Clear();
             StateHasChanged();
             return false;
         }
 
         error = null;
 
-        if (string.IsNullOrWhiteSpace(selectedKey) || !keys.Contains(selectedKey))
-        {
-            selectedKey = keys[0];
-        }
+        UpdateSelectionAfterKeyRefresh(ensureSelection: initialLoad);
 
-        if (!running)
+        if (running)
+        {
+            if (initialLoad)
+            {
+                await StartPollingAsync();
+            }
+        }
+        else
         {
             StateHasChanged();
-            return true;
-        }
-
-        if (initialLoad || _points.Count == 0)
-        {
-            await StartPollingAsync();
         }
 
         return true;
@@ -291,9 +304,7 @@
 
                 await InvokeAsync(async () =>
                 {
-                    var previousKeys = keys;
-                    var previousSelection = selectedKey;
-                    var hadKeysBefore = previousKeys.Count > 0;
+                    var hadKeysBefore = keys.Count > 0;
 
                     keys = latest;
 
@@ -305,21 +316,15 @@
                         }
 
                         error = "Waiting for live data…";
-                        _points = new List<PointDto>();
-                        _sinceTicks = 0;
-                        _totalReceived = 0;
+                        _selectedKeys = Array.Empty<string>();
+                        _chartStreams.Clear();
                         StateHasChanged();
                         return;
                     }
 
                     error = null;
 
-                    if (string.IsNullOrWhiteSpace(selectedKey) || !keys.Contains(selectedKey))
-                    {
-                        selectedKey = keys[0];
-                    }
-
-                    var selectionChanged = !string.Equals(previousSelection, selectedKey, StringComparison.Ordinal);
+                    var selectionChanged = UpdateSelectionAfterKeyRefresh(ensureSelection: !hadKeysBefore);
 
                     if (running && (selectionChanged || !hadKeysBefore))
                     {
@@ -368,6 +373,204 @@
             _keyRefreshCts?.Dispose();
             _keyRefreshCts = null;
             _keyRefreshTask = null;
+        }
+    }
+
+    private async Task OnKeyToggledAsync(string key, ChangeEventArgs e)
+    {
+        var isChecked = e.Value is bool boolean && boolean;
+
+        if (isChecked)
+        {
+            if (_selectedKeys.Contains(key, StringComparer.Ordinal))
+            {
+                return;
+            }
+
+            if (_selectedKeys.Count >= MaxChartsDisplayed)
+            {
+                selectionWarning = $"You can display up to {MaxChartsDisplayed} charts at a time.";
+                await InvokeAsync(StateHasChanged);
+                return;
+            }
+
+            selectionWarning = null;
+            _selectedKeys = _selectedKeys.Concat(new[] { key }).ToList();
+        }
+        else
+        {
+            if (!_selectedKeys.Contains(key, StringComparer.Ordinal))
+            {
+                return;
+            }
+
+            selectionWarning = null;
+            _selectedKeys = _selectedKeys.Where(k => !string.Equals(k, key, StringComparison.Ordinal)).ToList();
+        }
+
+        EnsureStreamsForSelection();
+
+        if (running)
+        {
+            await StartPollingAsync();
+        }
+        else
+        {
+            StateHasChanged();
+        }
+    }
+
+    private IEnumerable<ChartStream> GetActiveStreams()
+    {
+        foreach (var key in _selectedKeys)
+        {
+            if (_chartStreams.TryGetValue(key, out var stream))
+            {
+                yield return stream;
+            }
+        }
+    }
+
+    private void ResetStreams()
+    {
+        foreach (var key in _selectedKeys)
+        {
+            if (_chartStreams.TryGetValue(key, out var stream))
+            {
+                stream.Reset();
+            }
+            else
+            {
+                _chartStreams[key] = new ChartStream(key);
+            }
+        }
+
+        var keysToRemove = _chartStreams.Keys.Where(key => !_selectedKeys.Contains(key, StringComparer.Ordinal)).ToList();
+        foreach (var key in keysToRemove)
+        {
+            _chartStreams.Remove(key);
+        }
+    }
+
+    private void EnsureStreamsForSelection()
+    {
+        foreach (var key in _selectedKeys)
+        {
+            if (!_chartStreams.ContainsKey(key))
+            {
+                _chartStreams[key] = new ChartStream(key);
+            }
+        }
+
+        var keysToRemove = _chartStreams.Keys.Where(key => !_selectedKeys.Contains(key, StringComparer.Ordinal)).ToList();
+        foreach (var key in keysToRemove)
+        {
+            _chartStreams.Remove(key);
+        }
+    }
+
+    private bool UpdateSelectionAfterKeyRefresh(bool ensureSelection)
+    {
+        var sanitizedSelection = _selectedKeys
+            .Where(key => keys.Contains(key, StringComparer.Ordinal))
+            .ToList();
+
+        var selectionChanged = sanitizedSelection.Count != _selectedKeys.Count
+            || !_selectedKeys.SequenceEqual(sanitizedSelection, StringComparer.Ordinal);
+
+        if (ensureSelection && sanitizedSelection.Count == 0 && keys.Count > 0)
+        {
+            sanitizedSelection = keys.Take(MaxChartsDisplayed).ToList();
+            selectionChanged = true;
+        }
+
+        if (selectionChanged)
+        {
+            selectionWarning = null;
+        }
+
+        _selectedKeys = sanitizedSelection;
+
+        EnsureStreamsForSelection();
+
+        return selectionChanged;
+    }
+
+    private static string CreateCheckboxId(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return "key-unknown";
+        }
+
+        var builder = new StringBuilder("key-");
+        foreach (var ch in key)
+        {
+            builder.Append(char.IsLetterOrDigit(ch) ? char.ToLowerInvariant(ch) : '-');
+        }
+
+        return builder.ToString();
+    }
+
+    private bool IsSelected(string key)
+        => _selectedKeys.Contains(key, StringComparer.Ordinal);
+
+    private sealed class ChartStream
+    {
+        public ChartStream(string key)
+        {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+        }
+
+        public string Key { get; }
+
+        public List<PointDto> Points { get; } = new();
+
+        public long SinceTicks { get; private set; }
+
+        public long TotalReceived { get; private set; }
+
+        public bool Apply(IReadOnlyList<PointDto> batch)
+        {
+            if (batch is null)
+            {
+                throw new ArgumentNullException(nameof(batch));
+            }
+
+            var newPoints = 0;
+            foreach (var point in batch)
+            {
+                if (point is null)
+                {
+                    throw new ArgumentException("Batch cannot contain null points.", nameof(batch));
+                }
+
+                Points.Add(point);
+                SinceTicks = Math.Max(SinceTicks, point.X.Ticks);
+                newPoints++;
+            }
+
+            const int max = 2000;
+            if (Points.Count > max)
+            {
+                var excess = Points.Count - max;
+                Points.RemoveRange(0, excess);
+            }
+
+            if (newPoints == 0)
+            {
+                return false;
+            }
+
+            TotalReceived += newPoints;
+            return true;
+        }
+
+        public void Reset()
+        {
+            Points.Clear();
+            SinceTicks = 0;
+            TotalReceived = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce a multi-selection UI that can display up to three live charts simultaneously on the home page
- refactor the polling logic to manage per-key chart buffers with aggregated counters and warnings when exceeding the limit
- add a bUnit regression test to ensure three charts render by default when multiple keys are available

## Testing
- dotnet test EquipmentHubDemo/EquipmentHubDemo.Components.Tests/EquipmentHubDemo.Components.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68db27b86b78832cbc11097b4a5df1fa