### PR TITLE
Expand dashboard to nine chart grid

### DIFF
--- a/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/css/app.css
+++ b/EquipmentHubDemo/EquipmentHubDemo.Client/wwwroot/css/app.css
@@ -8,7 +8,8 @@ html, body {
 body {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
+    padding: 2rem 0;
     background-color: #f5f5f5;
     color: #1f2937;
 }

--- a/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components.Tests/HomePageTests.cs
@@ -77,23 +77,23 @@ public sealed class HomePageTests : TestContext
         {
             Assert.True(measurementClient.MeasurementRequests.Count > 0, "should request live measurements");
 
-            var badge = cut.Find("span.badge").TextContent;
-            Assert.Contains("Measurements received", badge);
-            Assert.Contains("1", badge);
-
             var chartPoints = cut.FindComponent<ChartIsland>().Instance;
             Assert.NotNull(chartPoints);
         }, timeout: TimeSpan.FromSeconds(5));
     }
 
     [Fact]
-    public void Home_RendersUpToThreeChartsByDefault()
+    public void Home_RendersUpToNineChartsByDefault()
     {
         // Arrange
         var measurementClient = new StubLiveMeasurementClient(
             keysSequence: new[]
             {
-                new[] { "Line A", "Line B", "Line C", "Line D" }
+                new[]
+                {
+                    "Line A", "Line B", "Line C", "Line D", "Line E",
+                    "Line F", "Line G", "Line H", "Line I", "Line J", "Line K"
+                }
             },
             measurementsSequence: new IReadOnlyList<PointDto>[]
             {
@@ -109,12 +109,14 @@ public sealed class HomePageTests : TestContext
         cut.WaitForAssertion(() =>
         {
             var chartIslands = cut.FindComponents<ChartIsland>();
-            Assert.Equal(3, chartIslands.Count);
+            Assert.Equal(9, chartIslands.Count);
 
-            var titles = cut.FindAll("h6.card-title").Select(e => e.TextContent.Trim()).ToList();
+            var titles = cut.FindAll("h6.chart-grid__title").Select(e => e.TextContent.Trim()).ToList();
             Assert.Contains("Line A", titles);
             Assert.Contains("Line B", titles);
             Assert.Contains("Line C", titles);
+            Assert.Contains("Line I", titles);
+            Assert.DoesNotContain("Line J", titles);
         }, timeout: TimeSpan.FromSeconds(2));
     }
 

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/ChartIsland.razor.css
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/ChartIsland.razor.css
@@ -1,6 +1,6 @@
 .chart-island__surface {
     width: 100%;
-    min-height: 24rem;
+    min-height: 26rem;
     display: flex;
 }
 

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor
@@ -1,59 +1,59 @@
 @page "/"
-@using Microsoft.AspNetCore.Components.Web
+@using System
+@using System.Linq
 @rendermode InteractiveWebAssembly
 @namespace EquipmentHubDemo.Components.Pages
 
 @inject ILiveMeasurementClient Measurements
 
-<h3>Live Measurements</h3>
-<p class="text-muted">Agent → Broker → Filter/Store → Live cache → (WASM UI)</p>
+<section class="page-intro">
+    <h3 class="page-intro__title">Live Measurements (Debug)</h3>
+    <p class="page-intro__subtitle text-muted">Charts update automatically as data arrives from the live cache.</p>
+</section>
 
 @if (!string.IsNullOrEmpty(error))
 {
     <div class="alert alert-danger">@error</div>
 }
-
-<div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
-    <div class="flex-grow-1">
-        <div class="d-flex flex-wrap align-items-center gap-3">
-            @foreach (var key in AvailableKeys)
-            {
-                var checkboxId = CreateCheckboxId(key);
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input"
-                           type="checkbox"
-                           id="@checkboxId"
-                           checked="@IsSelected(key)"
-                           @onchange="async e => await OnKeyToggledAsync(key, e)" />
-                    <label class="form-check-label" for="@checkboxId">@key</label>
-                </div>
-            }
-        </div>
-    </div>
-
-    <div class="d-flex align-items-center gap-2">
-        <button class="btn btn-sm btn-primary" @onclick="ToggleAsync">@((running ? "Pause" : "Run"))</button>
-        <span class="badge bg-primary text-wrap">Measurements received: @TotalReceived</span>
-        <span class="text-muted small">Active buffer: @ActiveBufferCount</span>
-    </div>
-</div>
-
-@if (!string.IsNullOrEmpty(selectionWarning))
+else
 {
-    <div class="alert alert-warning mt-2" role="alert">@selectionWarning</div>
-}
-
-<div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mt-2">
-    @foreach (var stream in GetActiveStreams())
-    {
-        <div class="col">
-            <div class="card h-100">
-                <div class="card-body">
-                    <h6 class="card-title text-muted">@stream.Key</h6>
-                    <ChartIsland Points="stream.Points"
-                                 Title="stream.Key" />
-                </div>
-            </div>
-        </div>
+    @{
+        var activeStreams = GetActiveStreams().ToList();
+        var placeholderCount = Math.Max(0, MaxChartsDisplayed - activeStreams.Count);
     }
-</div>
+
+    <div class="chart-grid__wrapper">
+        @if (activeStreams.Count == 0)
+        {
+            <div class="chart-grid__empty alert alert-info" role="status">
+                Waiting for live data…
+            </div>
+        }
+        else
+        {
+            <div class="chart-grid" role="list">
+                @foreach (var stream in activeStreams)
+                {
+                    <div class="chart-grid__cell" role="listitem">
+                        <div class="chart-grid__card">
+                            <h6 class="chart-grid__title text-muted">@stream.Key</h6>
+                            <ChartIsland Points="stream.Points"
+                                         Title="stream.Key" />
+                        </div>
+                    </div>
+                }
+
+                @for (var i = 0; i < placeholderCount; i++)
+                {
+                    <div class="chart-grid__cell" role="listitem">
+                        <div class="chart-grid__card chart-grid__card--placeholder">
+                            <div class="chart-grid__placeholder text-muted">
+                                Awaiting stream…
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
+}

--- a/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor.css
+++ b/EquipmentHubDemo/EquipmentHubDemo.Components/Pages/Home.razor.css
@@ -1,0 +1,82 @@
+.page-intro {
+    margin-bottom: 1.5rem;
+}
+
+.page-intro__title {
+    margin-bottom: 0.25rem;
+}
+
+.page-intro__subtitle {
+    margin-bottom: 0;
+}
+
+.chart-grid__wrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin: 0 auto;
+}
+
+.chart-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.5rem;
+    width: clamp(320px, 70vw, 1200px);
+}
+
+.chart-grid__cell {
+    display: flex;
+}
+
+.chart-grid__card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    background-color: #ffffff;
+    box-shadow: 0 0.75rem 1.5rem rgba(31, 41, 55, 0.08);
+    width: 100%;
+}
+
+.chart-grid__card--placeholder {
+    align-items: center;
+    justify-content: center;
+    min-height: 12rem;
+    background-image: linear-gradient(135deg, rgba(226, 232, 240, 0.35), rgba(203, 213, 225, 0.35));
+}
+
+.chart-grid__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.chart-grid__placeholder {
+    font-size: 0.9rem;
+    letter-spacing: 0.03em;
+}
+
+.chart-grid__empty {
+    width: clamp(320px, 70vw, 1200px);
+    text-align: center;
+}
+
+@media (max-width: 1199.98px) {
+    .chart-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 767.98px) {
+    .chart-grid {
+        grid-template-columns: minmax(0, 1fr);
+        width: 100%;
+    }
+
+    .chart-grid__empty {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- simplify the home page into a 3×3 LiveCharts grid with automatic placeholders instead of manual controls
- auto-select up to nine measurement streams and refresh polling when keys change
- style the dashboard for a centered 70% width layout and enlarge the LiveCharts surface
- update the component tests to reflect the new layout and selection limits

## Testing
- dotnet test EquipmentHubDemo.sln *(fails: package restore requires external feeds unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e40c67b110832c85ae7dc5e07401b0